### PR TITLE
Add `.DEFAULT_GOAL` setting

### DIFF
--- a/resources/make/config.mk
+++ b/resources/make/config.mk
@@ -29,3 +29,10 @@ MAKEFLAGS += --always-make
 #
 # https://www.gnu.org/software/make/manual/html_node/Special-Targets.html
 #.EXPORT_ALL_VARIABLES:
+
+# .DEFAULT_GOAL
+# Sets the default goal to be used if no targets were specified on the command line
+# (see Arguments to Specify the Goals). The .DEFAULT_GOAL variable allows you to discover 
+# the current default goal, restart the default goal selection algorithm by clearing 
+# its value, or to explicitly set the default goal.
+#.DEFAULT_GOAL := help


### PR DESCRIPTION
Added `.DEFAULT_GOAL` to be able to enable `help` as default target.